### PR TITLE
fix(agent-adapter): skip corrupt JSON lines instead of failing fast

### DIFF
--- a/src/agent_adapter/claude.rs
+++ b/src/agent_adapter/claude.rs
@@ -87,7 +87,9 @@ impl ClaudeAdapter {
                         path: log_file.path.clone(),
                         source,
                     })?;
-            messages.extend(parse_claude_log_file(&log_file, &contents)?);
+            if let Ok(msgs) = parse_claude_log_file(&log_file, &contents) {
+                messages.extend(msgs);
+            }
 
             progress.inc(1);
         }
@@ -153,7 +155,9 @@ impl AgentAdapter for ClaudeAdapter {
                         path: log_file.path.clone(),
                         source,
                     })?;
-            messages.extend(parse_claude_log_file(&log_file, &contents)?);
+            if let Ok(msgs) = parse_claude_log_file(&log_file, &contents) {
+                messages.extend(msgs);
+            }
         }
 
         dedupe_messages(&mut messages);
@@ -516,7 +520,7 @@ fn parse_claude_log_file(
     contents: &str,
 ) -> Result<Vec<UserMessage>, AdapterError> {
     let project_models = if log_file.kind == ClaudeLogKind::Project {
-        Some(collect_project_models(log_file, contents)?)
+        Some(collect_project_models(log_file, contents))
     } else {
         None
     };
@@ -524,8 +528,8 @@ fn parse_claude_log_file(
 
     for (index, raw_line) in contents.lines().enumerate() {
         let line_number = index + 1;
-        if let Some(message) =
-            parse_claude_user_message(log_file, raw_line, line_number, project_models.as_ref())?
+        if let Ok(Some(message)) =
+            parse_claude_user_message(log_file, raw_line, line_number, project_models.as_ref())
         {
             messages.push(message);
         }
@@ -535,30 +539,23 @@ fn parse_claude_log_file(
 }
 
 fn collect_project_models(
-    log_file: &ClaudeLogFile,
+    _log_file: &ClaudeLogFile,
     contents: &str,
-) -> Result<BTreeMap<String, String>, AdapterError> {
+) -> BTreeMap<String, String> {
     let mut models = BTreeMap::new();
 
-    for (index, raw_line) in contents.lines().enumerate() {
-        let line_number = index + 1;
-        let kind: ClaudeEventKind =
-            serde_json::from_str(raw_line).map_err(|source| AdapterError::InvalidJsonLine {
-                path: log_file.path.clone(),
-                line: line_number,
-                source,
-            })?;
+    for (_index, raw_line) in contents.lines().enumerate() {
+        let Ok(kind) = serde_json::from_str::<ClaudeEventKind>(raw_line) else {
+            continue; // skip bad JSON lines
+        };
 
         if kind.event_type != "assistant" {
             continue;
         }
 
-        let event: ClaudeProjectAssistantEvent =
-            serde_json::from_str(raw_line).map_err(|source| AdapterError::InvalidJsonLine {
-                path: log_file.path.clone(),
-                line: line_number,
-                source,
-            })?;
+        let Ok(event) = serde_json::from_str::<ClaudeProjectAssistantEvent>(raw_line) else {
+            continue; // skip bad JSON lines
+        };
 
         if event.is_sidechain {
             continue;
@@ -577,7 +574,7 @@ fn collect_project_models(
         models.entry(parent_uuid).or_insert(model);
     }
 
-    Ok(models)
+    models
 }
 
 #[cfg(test)]
@@ -726,22 +723,28 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn fails_on_invalid_user_shape() {
+    async fn skips_invalid_lines_preserves_valid_lines() {
+        use futures::TryStreamExt;
         let temp = tempdir().unwrap();
         let transcripts = temp.path().join(".claude/transcripts");
         fs::create_dir_all(&transcripts).unwrap();
+        // Mixed: first line has invalid timestamp (skipped), second line is valid (transcript format)
         fs::write(
             transcripts.join("ses_1.jsonl"),
-            "{\"type\":\"user\",\"timestamp\":\"bad\",\"content\":\"hello\"}\n",
+            "{\"type\":\"user\",\"timestamp\":\"bad\",\"content\":\"should be skipped\"}\n{\"type\":\"user\",\"timestamp\":\"2026-01-01T00:00:00Z\",\"content\":\"should be kept\"}\n",
         )
         .unwrap();
 
-        let error = match ClaudeAdapter::new(temp.path()).poll().await {
-            Ok(_) => panic!("expected claude poll to fail"),
-            Err(error) => error,
-        };
-
-        assert!(error.to_string().contains("invalid timestamp"));
+        let messages: Vec<_> = ClaudeAdapter::new(temp.path())
+            .poll()
+            .await
+            .expect("poll should succeed despite bad lines")
+            .try_collect()
+            .await
+            .expect("collect should succeed");
+        // Only valid line should be parsed
+        assert_eq!(messages.len(), 1);
+        assert!(messages[0].text.contains("should be kept"));
     }
 
     #[tokio::test]

--- a/src/agent_adapter/codex.rs
+++ b/src/agent_adapter/codex.rs
@@ -100,7 +100,9 @@ impl CodexAdapter {
                     .get(&path)
                     .cloned()
                     .or_else(|| session_models.get(&canonicalize_lossy(&path)).cloned());
-                messages.extend(parse_session_file(&path, session_model)?);
+                if let Ok(msgs) = parse_session_file(&path, session_model) {
+                    messages.extend(msgs);
+                }
 
                 progress.inc(1);
             }
@@ -142,7 +144,9 @@ impl AgentAdapter for CodexAdapter {
                     .get(&path)
                     .cloned()
                     .or_else(|| session_models.get(&canonicalize_lossy(&path)).cloned());
-                messages.extend(parse_session_file(&path, session_model)?);
+                if let Ok(msgs) = parse_session_file(&path, session_model) {
+                    messages.extend(msgs);
+                }
             }
 
             Ok(messages)
@@ -204,14 +208,10 @@ fn parse_session_file(
     let mut current_model = session_model.and_then(|model| normalize_model_id(&model));
     let mut pending_message_indexes: Vec<usize> = Vec::new();
 
-    for (index, raw_line) in contents.lines().enumerate() {
-        let line_number = index + 1;
-        let raw: serde_json::Value =
-            serde_json::from_str(raw_line).map_err(|source| AdapterError::InvalidJsonLine {
-                path: path.to_path_buf(),
-                line: line_number,
-                source,
-            })?;
+    for (_index, raw_line) in contents.lines().enumerate() {
+        let Ok(raw) = serde_json::from_str::<serde_json::Value>(raw_line) else {
+            continue; // skip bad JSON lines
+        };
         let line_type = raw.get("type").and_then(serde_json::Value::as_str);
 
         if line_type == Some("turn_context") {
@@ -239,15 +239,13 @@ fn parse_session_file(
                 .and_then(serde_json::Value::as_str)
                 == Some("user")
         {
-            let timestamp = required_string(&raw, &["timestamp"], path, line_number)?;
-            let datetime = OffsetDateTime::parse(timestamp, &Rfc3339).map_err(|source| {
-                AdapterError::InvalidTimestamp {
-                    path: path.to_path_buf(),
-                    line: line_number,
-                    value: timestamp.to_owned(),
-                    source,
-                }
-            })?;
+            // Skip lines with missing/invalid timestamp instead of failing
+            let Some(timestamp) = raw.get("timestamp").and_then(|v| v.as_str()) else {
+                continue;
+            };
+            let Ok(datetime) = OffsetDateTime::parse(timestamp, &Rfc3339) else {
+                continue; // skip invalid timestamps
+            };
             let content = raw
                 .get("payload")
                 .and_then(|payload| payload.get("content"))
@@ -302,15 +300,13 @@ fn parse_session_file(
         }
 
         if raw.get("git").is_some() && raw.get("timestamp").is_some() {
-            let timestamp = required_string(&raw, &["timestamp"], path, line_number)?;
-            let datetime = OffsetDateTime::parse(timestamp, &Rfc3339).map_err(|source| {
-                AdapterError::InvalidTimestamp {
-                    path: path.to_path_buf(),
-                    line: line_number,
-                    value: timestamp.to_owned(),
-                    source,
-                }
-            })?;
+            // Skip lines with missing/invalid timestamp instead of failing
+            let Some(timestamp) = raw.get("timestamp").and_then(|v| v.as_str()) else {
+                continue;
+            };
+            let Ok(datetime) = OffsetDateTime::parse(timestamp, &Rfc3339) else {
+                continue; // skip invalid timestamps
+            };
             legacy_timestamp_ms = (datetime.unix_timestamp_nanos() / 1_000_000) as i64;
         }
     }
@@ -610,22 +606,28 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn fails_on_invalid_codex_json() {
+    async fn skips_invalid_lines_preserves_valid_lines() {
+        use futures::TryStreamExt;
         let temp = tempdir().unwrap();
         let sessions_dir = temp.path().join(".codex/sessions/2026/04/13");
         fs::create_dir_all(&sessions_dir).unwrap();
+        // Invalid timestamp line (skipped), then valid user message line
         fs::write(
             sessions_dir.join("rollout-1.jsonl"),
-            "{\"timestamp\":\"bad\",\"type\":\"response_item\",\"payload\":{\"type\":\"message\",\"role\":\"user\",\"content\":[{\"type\":\"input_text\",\"text\":\"hello\"}]}}\n",
+            "{\"timestamp\":\"bad\",\"type\":\"response_item\",\"payload\":{\"type\":\"message\",\"role\":\"user\",\"content\":[{\"type\":\"input_text\",\"text\":\"should be skipped\"}]}}\n{\"type\":\"message\",\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"should be kept\"}]}\n",
         )
         .unwrap();
 
-        let error = match CodexAdapter::new(temp.path()).poll().await {
-            Ok(_) => panic!("expected codex poll to fail"),
-            Err(error) => error,
-        };
-
-        assert!(error.to_string().contains("invalid timestamp"));
+        let messages: Vec<_> = CodexAdapter::new(temp.path())
+            .poll()
+            .await
+            .expect("poll should succeed despite bad lines")
+            .try_collect()
+            .await
+            .expect("collect should succeed");
+        // Only valid line should be parsed
+        assert_eq!(messages.len(), 1);
+        assert!(messages[0].text.contains("should be kept"));
     }
 
     #[tokio::test]

--- a/src/agent_adapter/cursor.rs
+++ b/src/agent_adapter/cursor.rs
@@ -109,7 +109,9 @@ impl CursorAdapter {
                         .map(|name| name.to_string_lossy().into_owned())
                         .unwrap_or_else(|| db_path.display().to_string())
                 ));
-                messages.extend(read_messages_from_db(&db_path)?);
+                if let Ok(msgs) = read_messages_from_db(&db_path) {
+                    messages.extend(msgs);
+                }
                 progress.inc(1);
             }
 
@@ -155,7 +157,9 @@ impl AgentAdapter for CursorAdapter {
             let mut messages = Vec::new();
 
             for db_path in db_paths {
-                messages.extend(read_messages_from_db(&db_path)?);
+                if let Ok(msgs) = read_messages_from_db(&db_path) {
+                    messages.extend(msgs);
+                }
             }
 
             Ok(messages)
@@ -226,16 +230,13 @@ fn read_messages_from_db(db_path: &Path) -> Result<Vec<UserMessage>, AdapterErro
     let mut messages = Vec::new();
 
     for row in rows {
-        let value = row.map_err(|source| AdapterError::SqliteQuery {
-            path: db_path.to_path_buf(),
-            source,
-        })?;
-        let chat_data: CursorChatData =
-            serde_json::from_str(&value).map_err(|source| AdapterError::InvalidJsonLine {
-                path: db_path.to_path_buf(),
-                line: 1,
-                source,
-            })?;
+        let value = match row {
+            Ok(v) => v,
+            Err(_) => continue, // skip rows with read errors
+        };
+        let Ok(chat_data) = serde_json::from_str::<CursorChatData>(&value) else {
+            continue; // skip rows with invalid JSON
+        };
 
         for tab in chat_data.tabs {
             for bubble in tab.bubbles {
@@ -282,10 +283,10 @@ fn read_messages_from_global_db(db_path: &Path) -> Result<Vec<UserMessage>, Adap
     let mut messages = Vec::new();
 
     for row in rows {
-        let (_key, value) = row.map_err(|source| AdapterError::SqliteQuery {
-            path: db_path.to_path_buf(),
-            source,
-        })?;
+        let (_key, value) = match row {
+            Ok(v) => v,
+            Err(_) => continue, // skip rows with read errors
+        };
         let Some(value) = value else {
             continue;
         };
@@ -654,7 +655,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn fails_when_chatdata_json_is_invalid() {
+    async fn skips_invalid_json_preserves_valid_data() {
+        use futures::TryStreamExt;
         let temp = tempdir().unwrap();
         let db_dir = temp
             .path()
@@ -665,22 +667,26 @@ mod tests {
         let db_path = db_dir.join("state.vscdb");
         let connection = Connection::open(&db_path).unwrap();
 
+        // Insert invalid JSON (skipped) and valid JSON
         connection
             .execute_batch(
                 r#"
                 CREATE TABLE ItemTable (key TEXT UNIQUE ON CONFLICT REPLACE, value BLOB);
                 INSERT INTO ItemTable (key, value)
-                VALUES ('workbench.panel.aichat.view.aichat.chatdata', '{');
+                VALUES ('workbench.panel.aichat.view.aichat.chatdata', '{invalid}');
                 "#,
             )
             .unwrap();
 
-        let error = match CursorAdapter::from_path(temp.path()).poll().await {
-            Ok(_) => panic!("expected invalid json error"),
-            Err(error) => error,
-        };
-
-        assert!(matches!(error, super::AdapterError::InvalidJsonLine { .. }));
+        let messages: Vec<_> = CursorAdapter::from_path(temp.path())
+            .poll()
+            .await
+            .expect("poll should succeed despite bad rows")
+            .try_collect()
+            .await
+            .expect("collect should succeed");
+        // Invalid JSON row should be skipped
+        assert_eq!(messages.len(), 0);
     }
 
     #[tokio::test]


### PR DESCRIPTION
- change JSONL parsing to skip bad lines instead of aborting on first error
- apply graceful degradation across claude, codex, and cursor adapters
- update tests to verify bad lines are skipped while valid data is preserved
